### PR TITLE
갓 클래스에 SRP를 적용하여 CSV 파싱 책임을 분리하라

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationConfigOverride">
+      <CommitMessageValidationOverride>
+        <option name="enabled" value="true" />
+      </CommitMessageValidationOverride>
+    </option>
+  </component>
+</project>

--- a/.idea/modules/real-world-software-development.iml
+++ b/.idea/modules/real-world-software-development.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module">
+    <option name="configuration">
+      <map />
+    </option>
+  </component>
+</module>

--- a/.idea/modules/real-world-software-development.main.iml
+++ b/.idea/modules/real-world-software-development.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module">
+    <option name="configuration">
+      <map />
+    </option>
+  </component>
+</module>

--- a/src/main/java/chapter_02/BankStatementCSVParser.java
+++ b/src/main/java/chapter_02/BankStatementCSVParser.java
@@ -1,0 +1,45 @@
+package chapter_02;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CSV 파싱을 담당합니다.
+ */
+public class BankStatementCSVParser {
+
+  private static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+
+  /**
+   * CSV형태의 라인들을 파싱하여 도메인 클래스로 변환합니다.
+   *
+   * @param lines CSV형태로 작성된 라인 리스트
+   * @return 거래 내역 도메인 클래스 리스트
+   */
+  public List<BankTransaction> parseLinesFromCSV(final List<String> lines) {
+    final List<BankTransaction> bankTransactions = new ArrayList<>();
+    for (final String line : lines) {
+      bankTransactions.add(parseFromCSV(line));
+    }
+
+    return bankTransactions;
+  }
+
+  /**
+   * 한 줄의 CSV 포맷을 파싱하여 도메인 클래스로 변환합니다.
+   *
+   * @param line CSV line
+   * @return 변환된 도메인 클래스
+   */
+  private BankTransaction parseFromCSV(final String line) {
+    final String[] columns = line.split(",");
+
+    final LocalDate date = LocalDate.parse(columns[0], DATE_PATTERN);
+    final double amount = Double.parseDouble(columns[1]);
+    final String description = columns[2];
+
+    return new BankTransaction(date, amount, description);
+  }
+}

--- a/src/main/java/chapter_02/BankTransaction.java
+++ b/src/main/java/chapter_02/BankTransaction.java
@@ -1,0 +1,52 @@
+package chapter_02;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * 거래 내역 도메인 클래스.
+ */
+public class BankTransaction {
+  private final LocalDate date;
+  private final double amount;
+  private final String description;
+
+  BankTransaction(LocalDate date, double amount, String description) {
+    this.date = date;
+    this.amount = amount;
+    this.description = description;
+  }
+
+  LocalDate getDate() {
+    return date;
+  }
+
+  double getAmount() {
+    return amount;
+  }
+
+  String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[BankTransaction] date=%s, amount=%f, description=%s",
+        date.toString(), amount, description);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BankTransaction that = (BankTransaction) o;
+    return Double.compare(that.amount, amount) == 0 &&
+        Objects.equals(date, that.date) &&
+        Objects.equals(description, that.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(date, amount, description);
+  }
+}

--- a/src/main/java/chapter_02/BankTransactionAnalyzerSRP.java
+++ b/src/main/java/chapter_02/BankTransactionAnalyzerSRP.java
@@ -1,0 +1,38 @@
+package chapter_02;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Month;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * SRP 원칙을 적용한 거래내역 분석기
+ */
+public class BankTransactionAnalyzerSRP {
+  private static final String RESOURCES = "src/main/resources/";
+
+  public static void main(final String[] args) throws Exception {
+
+    final BankStatementCSVParser bankStatementParser = new BankStatementCSVParser();
+
+    final Path path = Paths.get(RESOURCES + args[0]);
+    final List<String> lines = Files.readAllLines(path);
+
+    final List<BankTransaction> bankTransactions = bankStatementParser.parseLinesFromCSV(lines);
+
+    System.out.println("The total for all transactions is " + calculateTotalAmount(bankTransactions));
+    System.out.println("Transactions in January " + selectInMonth(bankTransactions, Month.JANUARY));
+  }
+
+  private static double calculateTotalAmount(final List<BankTransaction> bankTransactions) {
+    return bankTransactions.stream().mapToDouble(BankTransaction::getAmount).sum();
+  }
+
+  private static List<BankTransaction> selectInMonth(final List<BankTransaction> bankTransactions, final Month month) {
+    return bankTransactions.stream()
+        .filter(bankStatement -> month.equals(bankStatement.getDate().getMonth()))
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
## 설명
- 파싱 로직을 구현하는 부분에 대해 다른 클래스에 책임을 위임했다.
- 기능을 독립적으로 구현했다.
- `BankTransactionCSVParser`의 기능을 재사용할 수 있다.

## 문제점 식별 
- `BankStatementAnalyzerSRP` 클래스는 여전히 응집도가 낮다
    - 파서, 계산, 화면으로 결과 전송 등 다양한 부분을 책임지고 있기 때문이다.
    - 계산 작업을 하는 로직은 파싱이나 결과 전송과는 직접적인 관련이 없다.