### PR TITLE
입출금 내역을 파싱하는 클래스와의 결합도를 제거하라

### DIFF
--- a/src/main/java/chapter_02/BankStatementAnalyzerDeCoupling.java
+++ b/src/main/java/chapter_02/BankStatementAnalyzerDeCoupling.java
@@ -1,0 +1,36 @@
+package chapter_02;
+
+import chapter_02.BankStatementProcessor;
+import chapter_02.BankTransaction;
+import chapter_02.interfaces.BankStatementParser;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Month;
+import java.util.List;
+
+public class BankStatementAnalyzerDeCoupling {
+  private static final String RESOURCES = "src/main/resources/";
+
+  public void analyze(final String fileName, final BankStatementParser bankStatementParser)
+      throws IOException {
+    final Path path = Paths.get(RESOURCES + fileName);
+    final List<String> lines = Files.readAllLines(path);
+
+    final List<BankTransaction> bankTransactions = bankStatementParser.parseLinesFrom(lines);
+
+    BankStatementProcessor bankStatementProcessor = new BankStatementProcessor(bankTransactions);
+
+    collectSummary(bankStatementProcessor);
+  }
+
+  private static void collectSummary(final BankStatementProcessor bankStatementProcessor) {
+    System.out.println("Total amount for all transactions : "
+        + bankStatementProcessor.calculateTotalAmount());
+    System.out.println("Total amount for transactions in January : "
+        + bankStatementProcessor.calculateTotalInMonth(Month.JANUARY));
+    System.out.println("Total salary received is : "
+        + bankStatementProcessor.calculateTotalForCategory("Salary"));
+  }
+}

--- a/src/main/java/chapter_02/BankStatementCSVParser.java
+++ b/src/main/java/chapter_02/BankStatementCSVParser.java
@@ -1,5 +1,6 @@
 package chapter_02;
 
+import chapter_02.interfaces.BankStatementParser;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -8,7 +9,7 @@ import java.util.List;
 /**
  * CSV 파싱을 담당합니다.
  */
-public class BankStatementCSVParser {
+public class BankStatementCSVParser implements BankStatementParser {
 
   private static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
@@ -18,10 +19,11 @@ public class BankStatementCSVParser {
    * @param lines CSV형태로 작성된 라인 리스트
    * @return 거래 내역 도메인 클래스 리스트
    */
-  public List<BankTransaction> parseLinesFromCSV(final List<String> lines) {
+  @Override
+  public List<BankTransaction> parseLinesFrom(final List<String> lines) {
     final List<BankTransaction> bankTransactions = new ArrayList<>();
     for (final String line : lines) {
-      bankTransactions.add(parseFromCSV(line));
+      bankTransactions.add(parseFrom(line));
     }
 
     return bankTransactions;
@@ -33,7 +35,8 @@ public class BankStatementCSVParser {
    * @param line CSV line
    * @return 변환된 도메인 클래스
    */
-  private BankTransaction parseFromCSV(final String line) {
+  @Override
+  public BankTransaction parseFrom(final String line) {
     final String[] columns = line.split(",");
 
     final LocalDate date = LocalDate.parse(columns[0], DATE_PATTERN);

--- a/src/main/java/chapter_02/BankTransactionAnalyzerSRP.java
+++ b/src/main/java/chapter_02/BankTransactionAnalyzerSRP.java
@@ -20,10 +20,10 @@ public class BankTransactionAnalyzerSRP {
     final Path path = Paths.get(RESOURCES + args[0]);
     final List<String> lines = Files.readAllLines(path);
 
-    final List<BankTransaction> bankTransactions = bankStatementParser.parseLinesFromCSV(lines);
-    final BankStatementProcessor bankStatementProcessor = new BankStatementProcessor(bankTransactions);
+//    final List<BankTransaction> bankTransactions = bankStatementParser.parseLinesFromCSV(lines);
+//    final BankStatementProcessor bankStatementProcessor = new BankStatementProcessor(bankTransactions);
 
-    collectSummary(bankStatementProcessor);
+//    collectSummary(bankStatementProcessor);
 
 //    System.out.println("The total for all transactions is " + calculateTotalAmount(bankTransactions));
 //    System.out.println("Transactions in January " + selectInMonth(bankTransactions, Month.JANUARY));

--- a/src/main/java/chapter_02/interfaces/BankStatementParser.java
+++ b/src/main/java/chapter_02/interfaces/BankStatementParser.java
@@ -1,0 +1,23 @@
+package chapter_02.interfaces;
+
+import chapter_02.BankTransaction;
+import java.util.List;
+
+public interface BankStatementParser {
+
+  /**
+   * 한 줄의 문자열 거래내역을 BankTransaction 도메인 클래스로 파싱합니다.
+   *
+   * @param line 입출금 거래 내역 라인
+   * @return 입출금 거래 내역
+   */
+  BankTransaction parseFrom(String line);
+
+  /**
+   * 입출금 거래내역 문자열 리스트를 파싱하여 리스트에 담아 리턴합니다.
+   *
+   * @param lines 입출금 거래내역 문자열 리스트
+   * @return 입출금 거래 내역 리스트
+   */
+  List<BankTransaction> parseLinesFrom(List<String> lines);
+}


### PR DESCRIPTION
## 개요
- `BankStatementAnalyzer`와 `BankStatementParser`간의 결합도를 제거하였다.
    - 만약 다른 형태의 파일을 파싱해야 하는 경우 구체 클래스에 의존하므로 변경에 취약하다.
- `BankStatementParser`라는 새로운 인터페이스 정의

## 문제점 식별
- 만약 특정 입출금 내역을 검색할 수 있는 기능이나, 주어진 날짜 범위 또는 특정 범주의 입출금 내역을 분석해야한다면?
- 거래내역의 연산을 책임지는 `BankTransactionProcessor` 클래스에 계속해서 메서드를 추가해나갈 것이다.
- 거래내역의 여러 속성을 조합할수록 코드가 점점 복잡해진다.
- 코드를 반복하게되고, 반복 로직과 비즈니스 로직이 결합되어 분리하기가 어려워진다.
- 결론적으로 **OCP 원칙**을 위배하는 것이다.